### PR TITLE
POST update delivery (positive and negative cases)

### DIFF
--- a/src/api/tests/orders/updateDelivery.spec.ts
+++ b/src/api/tests/orders/updateDelivery.spec.ts
@@ -1,0 +1,142 @@
+import { generateDeliveryData } from 'data/orders/generateDeliveryData.data';
+import {
+  negativeTestCasesForDelivery,
+  negativeTestCasesForDeliveryWithoutToken,
+  positiveTestCasesForDelivery,
+} from 'data/orders/updateDeliveryCases.data';
+import { deliverySchema } from 'data/schemas/order.schema';
+import { STATUS_CODES } from 'data/statusCodes';
+import { TAGS } from 'data/testTags.data';
+import { test } from 'fixtures/api-services.fixture';
+import { IOrderFromResponse } from 'types/orders.types';
+import { generateUniqueId } from 'utils/generateUniqueID.utils';
+import { validateResponse } from 'utils/validations/responseValidation';
+import { validateSchema } from 'utils/validations/schemaValidation';
+
+test.describe('[API] [Orders] Update delivery', () => {
+  let token = '';
+  const createdOrderIds: string[] = [];
+  const createdCustomerIds: string[] = [];
+  const createdProductIds: string[] = [];
+
+  let draftOrder: IOrderFromResponse | null = null;
+
+  test.beforeEach(async ({ signInApiService, ordersApiService }) => {
+    token = await signInApiService.loginAsLocalUser();
+    draftOrder = await ordersApiService.createDraftOrder(1, token);
+
+    createdOrderIds.push(draftOrder._id);
+    createdCustomerIds.push(draftOrder.customer._id);
+    draftOrder.products.forEach((p) => createdProductIds.push(p._id));
+  });
+
+  test.afterEach(async ({ dataDisposalUtils }) => {
+    await dataDisposalUtils.clearOrders(createdOrderIds);
+    await dataDisposalUtils.clearProducts(createdProductIds);
+    await dataDisposalUtils.clearCustomers(createdCustomerIds);
+    createdOrderIds.length = 0;
+    createdCustomerIds.length = 0;
+    createdProductIds.length = 0;
+  });
+
+  test.describe('Positive', () => {
+    positiveTestCasesForDelivery.forEach(
+      ({ name, data, expectedStatusCode, isSuccess, errorMessage }) => {
+        test(
+          `Should update delivery: ${name}`,
+          { tag: [TAGS.API, TAGS.ORDERS, TAGS.SMOKE, TAGS.REGRESSION] },
+          async ({ ordersController }) => {
+            const response = await ordersController.updateDelivery(
+              draftOrder!._id,
+              data,
+              token,
+            );
+
+            validateResponse(
+              response,
+              expectedStatusCode,
+              isSuccess,
+              errorMessage,
+            );
+            await validateSchema(deliverySchema, response.body.Order.delivery!);
+          },
+        );
+      },
+    );
+  });
+
+  test.describe('Negative', () => {
+    negativeTestCasesForDelivery.forEach(
+      ({ name, data, expectedStatusCode, isSuccess, errorMessage }) => {
+        test(
+          `Should NOT update delivery: ${name}`,
+          { tag: [TAGS.API, TAGS.ORDERS, TAGS.REGRESSION] },
+          async ({ ordersController }) => {
+            const response = await ordersController.updateDelivery(
+              draftOrder!._id,
+              data,
+              token,
+            );
+            validateResponse(
+              response,
+              expectedStatusCode,
+              isSuccess,
+              errorMessage,
+            );
+          },
+        );
+      },
+    );
+
+    negativeTestCasesForDeliveryWithoutToken.forEach(
+      ({
+        name,
+        data,
+        invalidToken,
+        expectedStatusCode,
+        isSuccess,
+        errorMessage,
+      }) => {
+        test(
+          `Should NOT update delivery: ${name}`,
+          { tag: [TAGS.API, TAGS.ORDERS, TAGS.REGRESSION] },
+          async ({ ordersController }) => {
+            const response = await ordersController.updateDelivery(
+              draftOrder!._id,
+              data,
+              invalidToken,
+            );
+            validateResponse(
+              response,
+              expectedStatusCode,
+              isSuccess,
+              errorMessage,
+            );
+          },
+        );
+      },
+    );
+
+    test(
+      'Should NOT update delivery: For non-existent order check',
+      { tag: [TAGS.API, TAGS.ORDERS, TAGS.REGRESSION] },
+      async ({ ordersController }) => {
+        const id = generateUniqueId();
+        const delivery = generateDeliveryData();
+
+        const response = await ordersController.updateDelivery(
+          id,
+          delivery,
+          token,
+        );
+
+        validateResponse(
+          response,
+          STATUS_CODES.NOT_FOUND,
+          false,
+          `Order with id '${id}' wasn't found`,
+        );
+      },
+    );
+  });
+});

--- a/src/data/orders/generateDeliveryData.data.ts
+++ b/src/data/orders/generateDeliveryData.data.ts
@@ -1,20 +1,29 @@
 import { faker } from '@faker-js/faker';
 import { COUNTRIES } from 'data/customers/countries.data';
-import { IDelivery } from 'types/orders.types';
+import { IAddress, IDelivery } from 'types/orders.types';
 import { DELIVERY } from './delivery.data';
 
-export function generateDeliveryData(params?: Partial<IDelivery>): IDelivery {
+export function generateDeliveryData(params?: {
+  finalDate?: string;
+  condition?: DELIVERY;
+  address?: Partial<IAddress>;
+}): IDelivery {
+  const defaultAddress: IAddress = {
+    country: faker.helpers.arrayElement(Object.values(COUNTRIES)),
+    city: faker.location.city(),
+    street: faker.location.street(),
+    house: faker.number.int({ min: 1, max: 999 }),
+    flat: faker.number.int({ min: 1, max: 9999 }),
+  };
+
   return {
-    finalDate: faker.date.future().toISOString().split('T')[0],
-    condition: faker.helpers.arrayElement(Object.values(DELIVERY)),
-    // condition: DELIVERY.PICKUP,
+    finalDate:
+      params?.finalDate ?? faker.date.future().toISOString().split('T')[0],
+    condition:
+      params?.condition ?? faker.helpers.arrayElement(Object.values(DELIVERY)),
     address: {
-      country: faker.helpers.arrayElement(Object.values(COUNTRIES)),
-      city: faker.location.city(),
-      street: faker.location.street(),
-      house: faker.number.int({ min: 1, max: 999 }),
-      flat: faker.number.int({ min: 1, max: 500 }),
+      ...defaultAddress,
+      ...(params?.address || {}),
     },
-    ...params,
   };
 }

--- a/src/data/orders/updateDeliveryCases.data.ts
+++ b/src/data/orders/updateDeliveryCases.data.ts
@@ -1,0 +1,213 @@
+import { STATUS_CODES } from 'data/statusCodes';
+import { generateDeliveryData } from './generateDeliveryData.data';
+import { COUNTRIES } from 'data/customers/countries.data';
+import { DELIVERY } from './delivery.data';
+
+export const positiveTestCasesForDelivery = [
+  {
+    name: 'Full valid delivery data',
+    data: generateDeliveryData(),
+    expectedStatusCode: STATUS_CODES.OK,
+    isSuccess: true,
+    errorMessage: null,
+  },
+  {
+    name: '1-char city',
+    data: generateDeliveryData({ address: { city: 'd' } }),
+    expectedStatusCode: STATUS_CODES.OK,
+    isSuccess: true,
+    errorMessage: null,
+  },
+  {
+    name: '1-char street',
+    data: generateDeliveryData({ address: { street: 'P' } }),
+    expectedStatusCode: STATUS_CODES.OK,
+    isSuccess: true,
+    errorMessage: null,
+  },
+  {
+    name: 'min value in house (house = 1)',
+    data: generateDeliveryData({ address: { house: 1 } }),
+    expectedStatusCode: STATUS_CODES.OK,
+    isSuccess: true,
+    errorMessage: null,
+  },
+  {
+    name: 'min value in flat (flat = 1)',
+    data: generateDeliveryData({ address: { flat: 1 } }),
+    expectedStatusCode: STATUS_CODES.OK,
+    isSuccess: true,
+    errorMessage: null,
+  },
+  {
+    name: '20-char City (max)',
+    data: generateDeliveryData({ address: { city: 'this textconsistsymb' } }),
+    expectedStatusCode: STATUS_CODES.OK,
+    isSuccess: true,
+    errorMessage: null,
+  },
+  {
+    name: '40-char Street (max)',
+    data: generateDeliveryData({
+      address: { street: 'Anastasiasu percalifragilisticnamesurnam' },
+    }),
+    expectedStatusCode: STATUS_CODES.OK,
+    isSuccess: true,
+    errorMessage: null,
+  },
+  {
+    name: 'house = 999 (max)',
+    data: generateDeliveryData({
+      address: { house: 999 },
+    }),
+    expectedStatusCode: STATUS_CODES.OK,
+    isSuccess: true,
+    errorMessage: null,
+  },
+  {
+    name: 'flat = 9999 (max)',
+    data: generateDeliveryData({
+      address: { flat: 9999 },
+    }),
+    expectedStatusCode: STATUS_CODES.OK,
+    isSuccess: true,
+    errorMessage: null,
+  },
+];
+
+export const negativeTestCasesForDelivery = [
+  {
+    name: 'Country is not from the suggested list',
+    data: generateDeliveryData({
+      address: { country: 'Australia' as unknown as COUNTRIES },
+    }),
+    expectedStatusCode: STATUS_CODES.BAD_REQUEST,
+    isSuccess: false,
+    errorMessage: 'Incorrect request body',
+  },
+  {
+    name: 'Delivery type is not from the suggested list',
+    data: generateDeliveryData({ condition: 'nothing' as unknown as DELIVERY }),
+    expectedStatusCode: STATUS_CODES.BAD_REQUEST,
+    isSuccess: false,
+    errorMessage: 'Incorrect request body',
+  },
+  {
+    name: 'City too long (21 chars)',
+    data: generateDeliveryData({ address: { city: 'this textconsistsymbs' } }),
+    expectedStatusCode: STATUS_CODES.BAD_REQUEST,
+    isSuccess: false,
+    errorMessage: 'Incorrect Delivery',
+  },
+  {
+    name: 'City is empty',
+    data: generateDeliveryData({ address: { city: '' } }),
+    expectedStatusCode: STATUS_CODES.BAD_REQUEST,
+    isSuccess: false,
+    errorMessage: 'Incorrect Delivery',
+  },
+  {
+    name: 'City consists numbers',
+    data: generateDeliveryData({ address: { city: 'thistextconsistsym1' } }),
+    expectedStatusCode: STATUS_CODES.BAD_REQUEST,
+    isSuccess: false,
+    errorMessage: 'Incorrect Delivery',
+  },
+  {
+    name: 'Street too long (41 chars)',
+    data: generateDeliveryData({
+      address: {
+        street: 'Anastasiasu percalifragilisticnamesurnaae',
+      },
+    }),
+    expectedStatusCode: STATUS_CODES.BAD_REQUEST,
+    isSuccess: false,
+    errorMessage: 'Incorrect Delivery',
+  },
+  {
+    name: 'Street is empty',
+    data: generateDeliveryData({ address: { street: '' } }),
+    expectedStatusCode: STATUS_CODES.BAD_REQUEST,
+    isSuccess: false,
+    errorMessage: 'Incorrect Delivery',
+  },
+  {
+    name: 'Street with @',
+    data: generateDeliveryData({
+      address: { street: 'Anastasia@upercalifra' },
+    }),
+    expectedStatusCode: STATUS_CODES.BAD_REQUEST,
+    isSuccess: false,
+    errorMessage: 'Incorrect Delivery',
+  },
+  {
+    name: 'house = 0',
+    data: generateDeliveryData({ address: { house: 0 } }),
+    expectedStatusCode: STATUS_CODES.BAD_REQUEST,
+    isSuccess: false,
+    errorMessage: 'Incorrect Delivery',
+  },
+  {
+    name: 'house = 1000',
+    data: generateDeliveryData({ address: { house: 1000 } }),
+    expectedStatusCode: STATUS_CODES.BAD_REQUEST,
+    isSuccess: false,
+    errorMessage: 'Incorrect Delivery',
+  },
+  {
+    name: 'flat = 0',
+    data: generateDeliveryData({ address: { flat: 0 } }),
+    expectedStatusCode: STATUS_CODES.BAD_REQUEST,
+    isSuccess: false,
+    errorMessage: 'Incorrect Delivery',
+  },
+  {
+    name: 'flat = 1000',
+    data: generateDeliveryData({ address: { flat: 10000 } }),
+    expectedStatusCode: STATUS_CODES.BAD_REQUEST,
+    isSuccess: false,
+    errorMessage: 'Incorrect Delivery',
+  },
+  {
+    name: 'flat is a string',
+    data: generateDeliveryData({
+      address: { flat: 'string' as unknown as number },
+    }),
+    expectedStatusCode: STATUS_CODES.BAD_REQUEST,
+    isSuccess: false,
+    errorMessage: 'Incorrect request body',
+  },
+  {
+    name: 'finalDate is empty',
+    data: generateDeliveryData({ finalDate: '' }),
+    expectedStatusCode: STATUS_CODES.BAD_REQUEST,
+    isSuccess: false,
+    errorMessage: 'Invalid final date',
+  },
+  {
+    name: 'invalid finalDate',
+    data: generateDeliveryData({ finalDate: '30-04-2023' }),
+    expectedStatusCode: STATUS_CODES.BAD_REQUEST,
+    isSuccess: false,
+    errorMessage: 'Invalid final date',
+  },
+];
+
+export const negativeTestCasesForDeliveryWithoutToken = [
+  {
+    name: 'Missing auth token',
+    data: generateDeliveryData(),
+    invalidToken: '',
+    expectedStatusCode: STATUS_CODES.UNAUTHORIZED,
+    isSuccess: false,
+    errorMessage: 'Not authorized',
+  },
+  {
+    name: 'Invalid auth token',
+    data: generateDeliveryData(),
+    invalidToken: 'invalid_token',
+    expectedStatusCode: STATUS_CODES.UNAUTHORIZED,
+    isSuccess: false,
+    errorMessage: 'Invalid access token',
+  },
+];

--- a/src/data/schemas/order.schema.ts
+++ b/src/data/schemas/order.schema.ts
@@ -21,10 +21,7 @@ export const commentSchema = {
 export const deliverySchema = {
   type: 'object',
   properties: {
-    finalDate: {
-      type: 'string',
-      format: 'date-time',
-    },
+    finalDate: { type: 'string', format: 'date-time' },
     condition: {
       type: 'string',
       enum: Object.values(DELIVERY),

--- a/src/types/orders.types.ts
+++ b/src/types/orders.types.ts
@@ -77,16 +77,18 @@ export interface IProductFromOrder extends IProduct {
   received: boolean;
 }
 
+export interface IAddress {
+  country: COUNTRIES;
+  city: string;
+  street: string;
+  house: number;
+  flat: number;
+}
+
 export interface IDelivery {
   finalDate: string;
   condition: DELIVERY;
-  address: {
-    country: COUNTRIES;
-    city: string;
-    street: string;
-    house: number;
-    flat: number;
-  };
+  address: IAddress;
 }
 
 export interface IHistory {


### PR DESCRIPTION
Добавила проверки для POST /api/orders/{id}/delivery - Update delivery details of an order 
+обновила файл generateDeliveryData (мб кто-то подскажет тут получше как сделать или оставить так)
+обновила немного схему и добавила дополнительный интерфейс для generateDeliveryData

<img width="928" alt="Снимок экрана 2025-06-22 в 12 40 32" src="https://github.com/user-attachments/assets/115e93d2-3671-4543-8acc-9d497133815b" />

<img width="928" alt="Снимок экрана 2025-06-22 в 12 40 35" src="https://github.com/user-attachments/assets/a0368406-08d7-4fa1-9cc2-97e9d4bb6d59" />


